### PR TITLE
Add oxbitnet-java crate — Java/JNI bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ## Highlights
 
 - **Pure WebGPU** — Custom WGSL kernels for ternary matrix operations (no WASM, no server)
-- **Multi-language** — TypeScript (`0xbitnet`), Rust (`oxbitnet`), Python (`oxbitnet`), C (`oxbitnet-ffi`)
+- **Multi-language** — TypeScript (`0xbitnet`), Rust (`oxbitnet`), Python (`oxbitnet`), Java/Android (`oxbitnet-java`), C (`oxbitnet-ffi`)
 - **Cross-platform** — Browsers, Node.js, Deno, native apps via wgpu
 - **Chat templates** — Built-in LLaMA 3 chat message formatting
 - **Automatic caching** — IndexedDB (browser) / disk cache (native)
@@ -96,6 +96,24 @@ model.chat(
 model.dispose()
 ```
 
+### Java
+
+```java
+import io.github.m96chan.oxbitnet.*;
+import java.util.List;
+
+try (BitNet model = BitNet.loadSync("model.gguf")) {
+    model.chat(
+        List.of(new ChatMessage("user", "Hello!")),
+        token -> {
+            System.out.print(token);
+            return true;
+        },
+        new GenerateOptions().temperature(0.7f)
+    );
+}
+```
+
 ### C / FFI
 
 ```c
@@ -147,6 +165,7 @@ More models are planned — see [#1](https://github.com/m96-chan/0xBitNet/issues
 | TypeScript / JS | [`0xbitnet`](https://www.npmjs.com/package/0xbitnet) | `npm install 0xbitnet` |
 | Rust | [`oxbitnet`](https://crates.io/crates/oxbitnet) | `cargo add oxbitnet` |
 | Python | [`oxbitnet`](https://pypi.org/project/oxbitnet/) | `pip install oxbitnet` |
+| Java / Android | `oxbitnet-java` | `cargo build -p oxbitnet-java --release` |
 | C / FFI | `oxbitnet-ffi` | `cargo build -p oxbitnet-ffi --release` |
 
 ## API Overview
@@ -178,6 +197,15 @@ More models are planned — see [#1](https://github.com/m96-chan/0xBitNet/issues
 | `model.generate(prompt, on_token)` | Generate with streaming callback |
 | `model.generate_sync(prompt)` | Generate, return full string |
 | `model.dispose()` | Release all GPU resources |
+
+### Java
+
+| Method | Description |
+|--------|-------------|
+| `BitNet.loadSync(source, options?)` | Load a GGUF model |
+| `model.chat(messages, callback, options?)` | Chat with streaming callback |
+| `model.generate(prompt, callback, options?)` | Generate with streaming callback |
+| `model.dispose()` / `model.close()` | Release all GPU resources (AutoCloseable) |
 
 ### C / FFI
 
@@ -246,6 +274,18 @@ pip install oxbitnet
 python packages/rust/crates/oxbitnet-python/examples/chat.py
 ```
 
+### Java CLI
+
+Minimal Java chat example using JNI bindings.
+
+```bash
+cd packages/rust
+cargo build -p oxbitnet-java --release
+cd crates/oxbitnet-java/examples
+javac -cp ../java/src/main/java:. Chat.java
+java -Djava.library.path=../../../../target/release -cp ../java/src/main/java:. Chat model.gguf "Hello!"
+```
+
 ### C CLI
 
 Minimal C example using the FFI bindings.
@@ -273,6 +313,7 @@ LD_LIBRARY_PATH=target/release ./chat model.gguf "Hello!"
 │       └── crates/
 │           ├── oxbitnet/           # Rust library (crates.io: oxbitnet)
 │           ├── oxbitnet-python/    # Python bindings via PyO3 (PyPI: oxbitnet)
+│           ├── oxbitnet-java/      # Java/JNI bindings (Android-ready)
 │           └── oxbitnet-ffi/       # C FFI bindings (cdylib + staticlib)
 ├── examples/
 │   ├── web-chat/           # Chat app demo (Vite)
@@ -287,6 +328,7 @@ See [Architecture](docs/architecture.md) for data flow and internals.
 
 - **TypeScript/JS**: Node.js 18+, a WebGPU-capable environment
 - **Rust**: Rust 1.75+, a Vulkan/Metal/DX12-capable GPU
+- **Java**: JDK 17+, a Vulkan/Metal/DX12-capable GPU
 - **Python**: Python 3.9+, `pip install oxbitnet`
 
 ## Contributing

--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -267,6 +267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +327,16 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -1264,6 +1280,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1728,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "oxbitnet-java"
+version = "0.3.1"
+dependencies = [
+ "futures",
+ "jni",
+ "oxbitnet",
+ "tokio",
 ]
 
 [[package]]
@@ -2145,6 +2187,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2846,6 +2897,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3263,6 +3324,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3295,6 +3365,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3332,6 +3417,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3344,6 +3435,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3353,6 +3450,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3380,6 +3483,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3389,6 +3498,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3404,6 +3519,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3413,6 +3534,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["crates/oxbitnet", "crates/oxbitnet-python", "crates/oxbitnet-ffi"]
+members = ["crates/oxbitnet", "crates/oxbitnet-python", "crates/oxbitnet-ffi", "crates/oxbitnet-java"]
 resolver = "2"

--- a/packages/rust/crates/oxbitnet-java/Cargo.toml
+++ b/packages/rust/crates/oxbitnet-java/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "oxbitnet-java"
+version = "0.3.1"
+edition = "2021"
+description = "Java/JNI bindings for oxbitnet — run BitNet b1.58 ternary LLMs with wgpu"
+license = "MIT"
+repository = "https://github.com/m96-chan/0xBitNet"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+oxbitnet = { path = "../oxbitnet" }
+jni = "0.21"
+tokio = { version = "1", features = ["rt-multi-thread"] }
+futures = "0.3"

--- a/packages/rust/crates/oxbitnet-java/README.md
+++ b/packages/rust/crates/oxbitnet-java/README.md
@@ -1,0 +1,125 @@
+# oxbitnet-java
+
+Java/JNI bindings for [oxbitnet](https://crates.io/crates/oxbitnet) — run [BitNet b1.58](https://github.com/microsoft/BitNet) ternary LLMs with GPU acceleration (wgpu).
+
+Part of [0xBitNet](https://github.com/m96-chan/0xBitNet).
+
+## Build
+
+```bash
+cargo build -p oxbitnet-java --release
+```
+
+Produces `target/release/liboxbitnet_java.so` (Linux) / `.dylib` (macOS) / `oxbitnet_java.dll` (Windows).
+
+## Quick Start
+
+```java
+import io.github.m96chan.oxbitnet.*;
+import java.util.List;
+
+try (BitNet model = BitNet.loadSync("model.gguf")) {
+    // Raw prompt
+    model.generate("Hello!", token -> {
+        System.out.print(token);
+        return true; // continue
+    });
+
+    // Chat messages
+    model.chat(
+        List.of(new ChatMessage("user", "Hello!")),
+        token -> {
+            System.out.print(token);
+            return true;
+        },
+        new GenerateOptions().temperature(0.7f).maxTokens(256)
+    );
+}
+```
+
+## API
+
+### Loading
+
+```java
+// Simple
+BitNet model = BitNet.loadSync("model.gguf");
+
+// With progress callback
+BitNet model = BitNet.loadSync("model.gguf", new LoadOptions()
+    .onProgress((phase, loaded, total, fraction) ->
+        System.err.printf("[%s] %.1f%%\n", phase, fraction * 100)));
+```
+
+### Generation
+
+```java
+// Raw prompt
+int tokens = model.generate("Once upon a time", token -> {
+    System.out.print(token);
+    return true; // return false to stop early
+});
+
+// With options
+model.generate("Hello!", callback, new GenerateOptions()
+    .temperature(0.7f)
+    .maxTokens(512)
+    .topK(40)
+    .repeatPenalty(1.1f)
+    .repeatLastN(64));
+```
+
+### Chat
+
+```java
+model.chat(
+    List.of(
+        new ChatMessage("system", "You are a helpful assistant."),
+        new ChatMessage("user", "What is 2+2?")
+    ),
+    token -> {
+        System.out.print(token);
+        return true;
+    }
+);
+```
+
+### Cleanup
+
+`BitNet` implements `AutoCloseable`:
+
+```java
+try (BitNet model = BitNet.loadSync("model.gguf")) {
+    // use model...
+} // automatically disposed
+```
+
+Or manually:
+
+```java
+model.dispose();
+```
+
+## Generation Options
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `maxTokens` | 256 | Maximum tokens to generate |
+| `temperature` | 1.0 | Sampling temperature |
+| `topK` | 50 | Top-k sampling |
+| `repeatPenalty` | 1.1 | Repetition penalty |
+| `repeatLastN` | 64 | Window for repetition penalty |
+
+## Running the Example
+
+```bash
+cd packages/rust
+cargo build -p oxbitnet-java --release
+cd crates/oxbitnet-java/examples
+javac -cp ../java/src/main/java:. Chat.java
+java -Djava.library.path=../../../../target/release -cp ../java/src/main/java:. Chat model.gguf "Hello!"
+```
+
+## License
+
+MIT

--- a/packages/rust/crates/oxbitnet-java/examples/Chat.java
+++ b/packages/rust/crates/oxbitnet-java/examples/Chat.java
@@ -1,0 +1,49 @@
+import io.github.m96chan.oxbitnet.BitNet;
+import io.github.m96chan.oxbitnet.ChatMessage;
+import io.github.m96chan.oxbitnet.GenerateOptions;
+import io.github.m96chan.oxbitnet.LoadOptions;
+
+import java.util.List;
+
+/**
+ * Minimal chat example using oxbitnet Java bindings.
+ *
+ * <p>Usage:
+ * <pre>
+ *   cargo build -p oxbitnet-java --release
+ *   javac -cp ../java/src/main/java:. Chat.java
+ *   java -Djava.library.path=../../../../target/release -cp ../java/src/main/java:. Chat model.gguf "Hello!"
+ * </pre>
+ */
+public class Chat {
+
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            System.err.println("Usage: java Chat <model.gguf> <prompt>");
+            System.exit(1);
+        }
+
+        String modelPath = args[0];
+        String userMessage = args[1];
+
+        System.err.println("Loading model: " + modelPath);
+
+        try (BitNet model = BitNet.loadSync(modelPath, new LoadOptions()
+                .onProgress((phase, loaded, total, fraction) ->
+                    System.err.printf("\r[%s] %.1f%%", phase, fraction * 100)))) {
+
+            System.err.println("\nModel loaded. Generating...\n");
+
+            model.chat(
+                List.of(new ChatMessage("user", userMessage)),
+                token -> {
+                    System.out.print(token);
+                    return true;
+                },
+                new GenerateOptions().temperature(0.7f).maxTokens(512)
+            );
+
+            System.out.println();
+        }
+    }
+}

--- a/packages/rust/crates/oxbitnet-java/java/build.gradle.kts
+++ b/packages/rust/crates/oxbitnet-java/java/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    java
+}
+
+group = "io.github.m96-chan"
+version = "0.3.1"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}

--- a/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/BitNet.java
+++ b/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/BitNet.java
@@ -1,0 +1,173 @@
+package io.github.m96chan.oxbitnet;
+
+import java.util.List;
+
+/**
+ * Main entry point for BitNet inference.
+ *
+ * <p>Loads a BitNet b1.58 ternary LLM from a GGUF file and provides streaming
+ * text generation via GPU (wgpu). Implements {@link AutoCloseable} for use with
+ * try-with-resources.
+ *
+ * <pre>{@code
+ * try (BitNet model = BitNet.loadSync("model.gguf")) {
+ *     model.generate("Hello!", token -> {
+ *         System.out.print(token);
+ *         return true;
+ *     });
+ * }
+ * }</pre>
+ */
+public class BitNet implements AutoCloseable {
+
+    static {
+        System.loadLibrary("oxbitnet_java");
+    }
+
+    private long nativeHandle;
+
+    private BitNet(long handle) {
+        this.nativeHandle = handle;
+    }
+
+    /**
+     * Load a BitNet model from a GGUF file path or URL.
+     *
+     * @param source path or URL to a GGUF model file
+     * @return a loaded BitNet model ready for inference
+     * @throws OxBitNetException if loading fails
+     */
+    public static BitNet loadSync(String source) {
+        long handle = nativeLoad(source, null);
+        if (handle == 0) {
+            throw new OxBitNetException("Failed to load model from: " + source);
+        }
+        return new BitNet(handle);
+    }
+
+    /**
+     * Load a BitNet model with options (progress callback, cache dir).
+     *
+     * @param source  path or URL to a GGUF model file
+     * @param options load options
+     * @return a loaded BitNet model ready for inference
+     * @throws OxBitNetException if loading fails
+     */
+    public static BitNet loadSync(String source, LoadOptions options) {
+        long handle = nativeLoad(source, options);
+        if (handle == 0) {
+            throw new OxBitNetException("Failed to load model from: " + source);
+        }
+        return new BitNet(handle);
+    }
+
+    /**
+     * Generate text from a raw prompt with streaming callback.
+     *
+     * @param prompt   the prompt string
+     * @param callback receives each token; return true to continue, false to stop
+     * @return number of tokens generated
+     * @throws OxBitNetException if generation fails or model is disposed
+     */
+    public int generate(String prompt, TokenCallback callback) {
+        return generate(prompt, callback, new GenerateOptions());
+    }
+
+    /**
+     * Generate text from a raw prompt with streaming callback and options.
+     *
+     * @param prompt   the prompt string
+     * @param callback receives each token; return true to continue, false to stop
+     * @param options  generation options (temperature, maxTokens, etc.)
+     * @return number of tokens generated
+     * @throws OxBitNetException if generation fails or model is disposed
+     */
+    public int generate(String prompt, TokenCallback callback, GenerateOptions options) {
+        checkNotDisposed();
+        return nativeGenerate(
+            nativeHandle, prompt,
+            options.maxTokens, options.temperature,
+            options.topK, options.repeatPenalty, options.repeatLastN,
+            callback
+        );
+    }
+
+    /**
+     * Generate text from chat messages with streaming callback.
+     *
+     * @param messages list of chat messages
+     * @param callback receives each token; return true to continue, false to stop
+     * @return number of tokens generated
+     * @throws OxBitNetException if generation fails or model is disposed
+     */
+    public int chat(List<ChatMessage> messages, TokenCallback callback) {
+        return chat(messages, callback, new GenerateOptions());
+    }
+
+    /**
+     * Generate text from chat messages with streaming callback and options.
+     *
+     * @param messages list of chat messages
+     * @param callback receives each token; return true to continue, false to stop
+     * @param options  generation options
+     * @return number of tokens generated
+     * @throws OxBitNetException if generation fails or model is disposed
+     */
+    public int chat(List<ChatMessage> messages, TokenCallback callback, GenerateOptions options) {
+        checkNotDisposed();
+        String[] roles = new String[messages.size()];
+        String[] contents = new String[messages.size()];
+        for (int i = 0; i < messages.size(); i++) {
+            roles[i] = messages.get(i).role();
+            contents[i] = messages.get(i).content();
+        }
+        return nativeChat(
+            nativeHandle, roles, contents,
+            options.maxTokens, options.temperature,
+            options.topK, options.repeatPenalty, options.repeatLastN,
+            callback
+        );
+    }
+
+    /**
+     * Release all GPU resources. Safe to call multiple times.
+     */
+    public void dispose() {
+        if (nativeHandle != 0) {
+            nativeFree(nativeHandle);
+            nativeHandle = 0;
+        }
+    }
+
+    /** Alias for {@link #dispose()}, enables try-with-resources. */
+    @Override
+    public void close() {
+        dispose();
+    }
+
+    private void checkNotDisposed() {
+        if (nativeHandle == 0) {
+            throw new OxBitNetException("Model has been disposed");
+        }
+    }
+
+    // -- Native methods --
+
+    private static native long nativeLoad(String source, LoadOptions options);
+
+    private static native int nativeGenerate(
+        long handle, String prompt,
+        long maxTokens, float temperature, long topK,
+        float repeatPenalty, long repeatLastN,
+        TokenCallback callback
+    );
+
+    private static native int nativeChat(
+        long handle, String[] roles, String[] contents,
+        long maxTokens, float temperature, long topK,
+        float repeatPenalty, long repeatLastN,
+        TokenCallback callback
+    );
+
+    private static native void nativeFree(long handle);
+}

--- a/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/ChatMessage.java
+++ b/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/ChatMessage.java
@@ -1,0 +1,10 @@
+package io.github.m96chan.oxbitnet;
+
+/**
+ * A chat message with a role and content.
+ *
+ * @param role    the message role ("system", "user", or "assistant")
+ * @param content the message text
+ */
+public record ChatMessage(String role, String content) {
+}

--- a/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/GenerateOptions.java
+++ b/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/GenerateOptions.java
@@ -1,0 +1,46 @@
+package io.github.m96chan.oxbitnet;
+
+/**
+ * Options for text generation. Uses a builder pattern — all setters return
+ * {@code this} for chaining.
+ *
+ * <pre>{@code
+ * new GenerateOptions()
+ *     .temperature(0.7f)
+ *     .maxTokens(512)
+ *     .topK(40)
+ * }</pre>
+ */
+public class GenerateOptions {
+
+    long maxTokens = 256;
+    float temperature = 1.0f;
+    long topK = 50;
+    float repeatPenalty = 1.1f;
+    long repeatLastN = 64;
+
+    public GenerateOptions maxTokens(long maxTokens) {
+        this.maxTokens = maxTokens;
+        return this;
+    }
+
+    public GenerateOptions temperature(float temperature) {
+        this.temperature = temperature;
+        return this;
+    }
+
+    public GenerateOptions topK(long topK) {
+        this.topK = topK;
+        return this;
+    }
+
+    public GenerateOptions repeatPenalty(float repeatPenalty) {
+        this.repeatPenalty = repeatPenalty;
+        return this;
+    }
+
+    public GenerateOptions repeatLastN(long repeatLastN) {
+        this.repeatLastN = repeatLastN;
+        return this;
+    }
+}

--- a/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/LoadOptions.java
+++ b/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/LoadOptions.java
@@ -1,0 +1,47 @@
+package io.github.m96chan.oxbitnet;
+
+/**
+ * Options for loading a BitNet model.
+ *
+ * <pre>{@code
+ * new LoadOptions()
+ *     .onProgress((phase, loaded, total, fraction) ->
+ *         System.err.printf("[%s] %.1f%%\n", phase, fraction * 100))
+ *     .cacheDir("/tmp/oxbitnet-cache")
+ * }</pre>
+ */
+public class LoadOptions {
+
+    /** Progress callback (accessed from native code). */
+    ProgressCallback onProgress;
+
+    /** Cache directory path (accessed from native code). */
+    String cacheDir;
+
+    public LoadOptions onProgress(ProgressCallback callback) {
+        this.onProgress = callback;
+        return this;
+    }
+
+    public LoadOptions cacheDir(String path) {
+        this.cacheDir = path;
+        return this;
+    }
+
+    /**
+     * Callback invoked during model loading to report progress.
+     */
+    @FunctionalInterface
+    public interface ProgressCallback {
+
+        /**
+         * Called with progress information.
+         *
+         * @param phase    current phase ("download", "parse", or "upload")
+         * @param loaded   bytes/items loaded so far
+         * @param total    total bytes/items expected
+         * @param fraction progress as a fraction (0.0 to 1.0)
+         */
+        void onProgress(String phase, long loaded, long total, double fraction);
+    }
+}

--- a/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/LoadProgress.java
+++ b/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/LoadProgress.java
@@ -1,0 +1,12 @@
+package io.github.m96chan.oxbitnet;
+
+/**
+ * Immutable snapshot of model loading progress.
+ *
+ * @param phase    current phase ("download", "parse", or "upload")
+ * @param loaded   bytes/items loaded so far
+ * @param total    total bytes/items expected
+ * @param fraction progress as a fraction (0.0 to 1.0)
+ */
+public record LoadProgress(String phase, long loaded, long total, double fraction) {
+}

--- a/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/OxBitNetException.java
+++ b/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/OxBitNetException.java
@@ -1,0 +1,15 @@
+package io.github.m96chan.oxbitnet;
+
+/**
+ * Runtime exception thrown by oxbitnet operations (model loading, generation).
+ */
+public class OxBitNetException extends RuntimeException {
+
+    public OxBitNetException(String message) {
+        super(message);
+    }
+
+    public OxBitNetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/TokenCallback.java
+++ b/packages/rust/crates/oxbitnet-java/java/src/main/java/io/github/m96chan/oxbitnet/TokenCallback.java
@@ -1,0 +1,16 @@
+package io.github.m96chan.oxbitnet;
+
+/**
+ * Callback for streaming token output during text generation.
+ */
+@FunctionalInterface
+public interface TokenCallback {
+
+    /**
+     * Called for each generated token.
+     *
+     * @param token the generated token string
+     * @return {@code true} to continue generation, {@code false} to stop early
+     */
+    boolean onToken(String token);
+}

--- a/packages/rust/crates/oxbitnet-java/src/lib.rs
+++ b/packages/rust/crates/oxbitnet-java/src/lib.rs
@@ -1,0 +1,332 @@
+//! Java/JNI bindings for oxbitnet.
+//!
+//! Provides JNI native methods called by the `io.github.m96chan.oxbitnet.BitNet`
+//! Java class. Follows the same pattern as the Python (PyO3) bindings: owns a
+//! `tokio::Runtime`, calls `block_on()` to bridge async→sync, and delivers
+//! tokens via callback.
+
+use std::path::PathBuf;
+
+use futures::StreamExt;
+use jni::objects::{JClass, JObject, JString, JValue};
+use jni::sys::{jfloat, jint, jlong};
+use jni::JNIEnv;
+
+struct JavaBitNet {
+    inner: Option<oxbitnet::BitNet>,
+    runtime: tokio::runtime::Runtime,
+}
+
+/// Throw an `OxBitNetException` and return `default`.
+fn throw<T>(env: &mut JNIEnv, msg: &str, default: T) -> T {
+    let _ = env.throw_new("io/github/m96chan/oxbitnet/OxBitNetException", msg);
+    default
+}
+
+// ---------------------------------------------------------------------------
+// Load
+// ---------------------------------------------------------------------------
+
+/// `static native long nativeLoad(String source, Object loadOptions);`
+#[no_mangle]
+pub extern "system" fn Java_io_github_m96chan_oxbitnet_BitNet_nativeLoad<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    source: JString<'local>,
+    load_options: JObject<'local>,
+) -> jlong {
+    let source_str: String = match env.get_string(&source) {
+        Ok(s) => s.into(),
+        Err(e) => return throw(&mut env, &format!("Invalid source string: {e}"), 0),
+    };
+
+    let mut opts = oxbitnet::LoadOptions::default();
+
+    // Extract fields from LoadOptions if non-null
+    if !load_options.is_null() {
+        // cacheDir
+        if let Ok(cache_dir_obj) = env.get_field(&load_options, "cacheDir", "Ljava/lang/String;") {
+            if let Ok(cache_dir_jobj) = cache_dir_obj.l() {
+                if !cache_dir_jobj.is_null() {
+                    let cache_dir_jstr = JString::from(cache_dir_jobj);
+                    let cache_dir: Option<String> = env.get_string(&cache_dir_jstr).ok().map(|s| s.into());
+                    if let Some(dir) = cache_dir {
+                        opts.cache_dir = Some(PathBuf::from(dir));
+                    }
+                }
+            }
+        }
+
+        // Progress callback — we need to call it from the async block.
+        // We create a GlobalRef so it survives across the block_on boundary.
+        if let Ok(progress_cb_val) =
+            env.get_field(&load_options, "onProgress", "Lio/github/m96chan/oxbitnet/LoadOptions$ProgressCallback;")
+        {
+            if let Ok(progress_cb_obj) = progress_cb_val.l() {
+                if !progress_cb_obj.is_null() {
+                    if let Ok(global_cb) = env.new_global_ref(progress_cb_obj) {
+                        // Get JavaVM so we can attach from the callback
+                        if let Ok(jvm) = env.get_java_vm() {
+                            opts.on_progress = Some(Box::new(move |p: oxbitnet::LoadProgress| {
+                                if let Ok(mut cb_env) = jvm.attach_current_thread() {
+                                    let phase_str = match p.phase {
+                                        oxbitnet::model::loader::LoadPhase::Download => "download",
+                                        oxbitnet::model::loader::LoadPhase::Parse => "parse",
+                                        oxbitnet::model::loader::LoadPhase::Upload => "upload",
+                                    };
+                                    if let Ok(j_phase) = cb_env.new_string(phase_str) {
+                                        let _ = cb_env.call_method(
+                                            &global_cb,
+                                            "onProgress",
+                                            "(Ljava/lang/String;JJD)V",
+                                            &[
+                                                JValue::Object(&j_phase.into()),
+                                                JValue::Long(p.loaded as i64),
+                                                JValue::Long(p.total as i64),
+                                                JValue::Double(p.fraction),
+                                            ],
+                                        );
+                                    }
+                                }
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => return throw(&mut env, &format!("Failed to create runtime: {e}"), 0),
+    };
+
+    match runtime.block_on(oxbitnet::BitNet::load(&source_str, opts)) {
+        Ok(bitnet) => {
+            let handle = Box::new(JavaBitNet {
+                inner: Some(bitnet),
+                runtime,
+            });
+            Box::into_raw(handle) as jlong
+        }
+        Err(e) => throw(&mut env, &format!("{e}"), 0),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generate (raw prompt)
+// ---------------------------------------------------------------------------
+
+/// `static native int nativeGenerate(long handle, String prompt, long maxTokens,
+///     float temperature, long topK, float repeatPenalty, long repeatLastN,
+///     TokenCallback callback);`
+#[no_mangle]
+pub extern "system" fn Java_io_github_m96chan_oxbitnet_BitNet_nativeGenerate<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    prompt: JString<'local>,
+    max_tokens: jlong,
+    temperature: jfloat,
+    top_k: jlong,
+    repeat_penalty: jfloat,
+    repeat_last_n: jlong,
+    callback: JObject<'local>,
+) -> jint {
+    if handle == 0 {
+        return throw(&mut env, "Model handle is null", -1);
+    }
+
+    let prompt_str: String = match env.get_string(&prompt) {
+        Ok(s) => s.into(),
+        Err(e) => return throw(&mut env, &format!("Invalid prompt string: {e}"), -1),
+    };
+
+    let java_bitnet = unsafe { &mut *(handle as *mut JavaBitNet) };
+    let bitnet = match java_bitnet.inner.as_mut() {
+        Some(m) => m,
+        None => return throw(&mut env, "Model has been disposed", -1),
+    };
+
+    let options = oxbitnet::GenerateOptions {
+        max_tokens: max_tokens as usize,
+        temperature,
+        top_k: top_k as usize,
+        repeat_penalty,
+        repeat_last_n: repeat_last_n as usize,
+    };
+
+    let mut stream = bitnet.generate(&prompt_str, options);
+    let mut count: i32 = 0;
+
+    let has_callback = !callback.is_null();
+
+    java_bitnet.runtime.block_on(async {
+        while let Some(token) = stream.next().await {
+            count += 1;
+            if has_callback {
+                match env.new_string(&token) {
+                    Ok(j_token) => {
+                        let result = env.call_method(
+                            &callback,
+                            "onToken",
+                            "(Ljava/lang/String;)Z",
+                            &[JValue::Object(&j_token.into())],
+                        );
+                        match result {
+                            Ok(ret) => {
+                                if let Ok(cont) = ret.z() {
+                                    if !cont {
+                                        break;
+                                    }
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    Err(_) => continue,
+                }
+            }
+        }
+    });
+
+    count
+}
+
+// ---------------------------------------------------------------------------
+// Chat
+// ---------------------------------------------------------------------------
+
+/// `static native int nativeChat(long handle, String[] roles, String[] contents,
+///     long maxTokens, float temperature, long topK, float repeatPenalty,
+///     long repeatLastN, TokenCallback callback);`
+#[no_mangle]
+pub extern "system" fn Java_io_github_m96chan_oxbitnet_BitNet_nativeChat<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    handle: jlong,
+    roles: JObject<'local>,    // String[]
+    contents: JObject<'local>, // String[]
+    max_tokens: jlong,
+    temperature: jfloat,
+    top_k: jlong,
+    repeat_penalty: jfloat,
+    repeat_last_n: jlong,
+    callback: JObject<'local>,
+) -> jint {
+    use jni::objects::JObjectArray;
+
+    if handle == 0 {
+        return throw(&mut env, "Model handle is null", -1);
+    }
+
+    let roles_arr: &JObjectArray = roles.as_ref().into();
+    let contents_arr: &JObjectArray = contents.as_ref().into();
+
+    let num_messages = match env.get_array_length(roles_arr) {
+        Ok(n) => n as usize,
+        Err(e) => return throw(&mut env, &format!("Failed to get roles array length: {e}"), -1),
+    };
+
+    let mut chat_messages = Vec::with_capacity(num_messages);
+    for i in 0..num_messages {
+        let role_obj = match env.get_object_array_element(roles_arr, i as i32) {
+            Ok(o) => o,
+            Err(e) => {
+                return throw(&mut env, &format!("Failed to get role[{i}]: {e}"), -1);
+            }
+        };
+        let content_obj = match env.get_object_array_element(contents_arr, i as i32) {
+            Ok(o) => o,
+            Err(e) => {
+                return throw(&mut env, &format!("Failed to get content[{i}]: {e}"), -1);
+            }
+        };
+
+        let role: String = match env.get_string(&JString::from(role_obj)) {
+            Ok(s) => s.into(),
+            Err(e) => {
+                return throw(&mut env, &format!("Invalid role string at [{i}]: {e}"), -1);
+            }
+        };
+        let content: String = match env.get_string(&JString::from(content_obj)) {
+            Ok(s) => s.into(),
+            Err(e) => {
+                return throw(&mut env, &format!("Invalid content string at [{i}]: {e}"), -1);
+            }
+        };
+
+        chat_messages.push(oxbitnet::ChatMessage { role, content });
+    }
+
+    let java_bitnet = unsafe { &mut *(handle as *mut JavaBitNet) };
+    let bitnet = match java_bitnet.inner.as_mut() {
+        Some(m) => m,
+        None => return throw(&mut env, "Model has been disposed", -1),
+    };
+
+    let options = oxbitnet::GenerateOptions {
+        max_tokens: max_tokens as usize,
+        temperature,
+        top_k: top_k as usize,
+        repeat_penalty,
+        repeat_last_n: repeat_last_n as usize,
+    };
+
+    let mut stream = bitnet.generate_chat(&chat_messages, options);
+    let mut count: i32 = 0;
+
+    let has_callback = !callback.is_null();
+
+    java_bitnet.runtime.block_on(async {
+        while let Some(token) = stream.next().await {
+            count += 1;
+            if has_callback {
+                match env.new_string(&token) {
+                    Ok(j_token) => {
+                        let result = env.call_method(
+                            &callback,
+                            "onToken",
+                            "(Ljava/lang/String;)Z",
+                            &[JValue::Object(&j_token.into())],
+                        );
+                        match result {
+                            Ok(ret) => {
+                                if let Ok(cont) = ret.z() {
+                                    if !cont {
+                                        break;
+                                    }
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    Err(_) => continue,
+                }
+            }
+        }
+    });
+
+    count
+}
+
+// ---------------------------------------------------------------------------
+// Free
+// ---------------------------------------------------------------------------
+
+/// `static native void nativeFree(long handle);`
+#[no_mangle]
+pub extern "system" fn Java_io_github_m96chan_oxbitnet_BitNet_nativeFree(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+) {
+    if handle == 0 {
+        return;
+    }
+    let mut java_bitnet = unsafe { Box::from_raw(handle as *mut JavaBitNet) };
+    if let Some(ref mut model) = java_bitnet.inner {
+        model.dispose();
+    }
+    // Box drops here, runtime shuts down
+}


### PR DESCRIPTION
## Summary

- Add `oxbitnet-java` crate with JNI native methods wrapping `oxbitnet` directly (same pattern as `oxbitnet-python` with PyO3)
- Java API: `BitNet.loadSync()`, `generate()`, `chat()` with `TokenCallback` streaming, `AutoCloseable` support
- Includes Java source files (`io.github.m96chan.oxbitnet` package), Gradle build stub, `Chat.java` example, and crate README

Closes #5

## Details

**Rust side** (`src/lib.rs`):
- `JavaBitNet` struct owns `Option<BitNet>` + `tokio::Runtime` (same as Python)
- JNI functions: `nativeLoad`, `nativeGenerate`, `nativeChat`, `nativeFree`
- Progress callback via `GlobalRef` + `JavaVM::attach_current_thread`
- Token callback: `boolean onToken(String)` — return `false` to stop early
- Errors thrown as `OxBitNetException` via `env.throw_new()`

**Java side** (7 files):
- `BitNet` — main class, `AutoCloseable`, stores `long nativeHandle`
- `ChatMessage` — record `(role, content)`
- `GenerateOptions` — builder pattern (maxTokens, temperature, topK, repeatPenalty, repeatLastN)
- `TokenCallback` — `@FunctionalInterface`
- `LoadOptions` — progress callback + cache dir
- `LoadProgress` — record for progress info
- `OxBitNetException` — RuntimeException subclass

## Test plan

- [x] `cargo build -p oxbitnet-java` compiles to `.so`
- [x] `cargo clippy -p oxbitnet-java -- -D warnings` passes clean
- [ ] Compile and run `Chat.java` example with a GGUF model
- [ ] Verify: loads model, streams tokens via callback, clean shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)