### PR TITLE
Test: run the shaders on a real GPU, not just their references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4937,6 +4937,53 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7513,10 +7560,11 @@
     },
     "packages/core": {
       "name": "0xbitnet",
-      "version": "0.4.0",
+      "version": "0.5.2",
       "license": "MIT",
       "devDependencies": {
         "@webgpu/types": "^0.1.52",
+        "playwright": "^1.49.0",
         "tsup": "^8.3.0",
         "typescript": "^5.7.0",
         "vitest": "^4.0.18"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
     "dev": "tsup --watch",
     "lint": "tsc --noEmit",
     "test": "vitest run",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test:gpu": "vitest run --config vitest.gpu.config.ts"
   },
   "keywords": [
     "bitnet",
@@ -47,6 +48,7 @@
     "@webgpu/types": "^0.1.52",
     "tsup": "^8.3.0",
     "typescript": "^5.7.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "playwright": "^1.49.0"
   }
 }

--- a/packages/core/src/shaders/__tests__/gpu/shaders.gpu.test.ts
+++ b/packages/core/src/shaders/__tests__/gpu/shaders.gpu.test.ts
@@ -1,0 +1,249 @@
+import { beforeAll, afterAll, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createRunner, params, type Runner } from "../helpers/gpu.js";
+import {
+  refActivation,
+  refDequantize,
+  refElementwise,
+  refQuantize,
+  refRMSNorm,
+  refRoPE,
+  refSoftmax,
+} from "../helpers/reference.js";
+
+const shader = (name: string) =>
+  readFileSync(fileURLToPath(new URL(`../../${name}.wgsl`, import.meta.url)), "utf8");
+
+let runner: Runner | null = null;
+beforeAll(async () => {
+  runner = await createRunner();
+}, 120_000);
+afterAll(async () => {
+  await runner?.close();
+});
+
+/**
+ * Skips rather than fails without a GPU. CI runs on ubuntu-latest and has none,
+ * and a suite that cannot run there should not be the one gating pull requests.
+ */
+const gpu = (name: string, body: (r: Runner) => Promise<void>) =>
+  it(name, async () => {
+    if (!runner) return;
+    await body(runner);
+  }, 60_000);
+
+/**
+ * Agreement, not equality: the reference runs in f64 and the shader in f32.
+ *
+ * An element passes on either measure. Relative alone is useless where the
+ * result nears zero through cancellation, and absolute alone is useless where
+ * the values are large.
+ */
+const agree = (
+  got: ArrayLike<number>,
+  want: ArrayLike<number>,
+  { rel = 1e-5, abs = 1e-6 }: { rel?: number; abs?: number } = {},
+) => {
+  let worstRel = 0;
+  for (let i = 0; i < want.length; i += 1) {
+    const diff = Math.abs(got[i]! - want[i]!);
+    if (diff <= abs) continue;
+    worstRel = Math.max(worstRel, diff / Math.max(1e-6, Math.abs(want[i]!)));
+  }
+  expect(worstRel).toBeLessThan(rel);
+};
+
+const wave = (n: number, k = 0.37) => Float32Array.from({ length: n }, (_, i) => Math.sin(i * k) * 2);
+
+describe("rmsnorm.wgsl", () => {
+  // D deliberately spans the 256-wide workgroup: below it, exactly on it, and
+  // not a multiple of it — the strided loop and the reduction both depend on
+  // which of those it is.
+  for (const [N, D] of [[2, 8], [1, 256], [3, 300], [2, 2560]] as const) {
+    gpu(`matches the reference at N=${N} D=${D}`, async (r) => {
+      const input = wave(N * D);
+      const weight = Float32Array.from({ length: D }, (_, i) => 0.5 + Math.cos(i * 0.11) * 0.4);
+      const eps = 1e-5;
+      const [out] = await r.run({
+        code: shader("rmsnorm"),
+        bindings: [
+          { kind: "storage", data: input },
+          { kind: "storage", data: weight },
+          { kind: "out", type: "f32", length: N * D },
+          { kind: "uniform", data: params([["u32", N], ["u32", D], ["f32", eps]]) },
+        ],
+        workgroups: [N],
+      });
+      agree(out!, refRMSNorm(input, weight, N, D, eps));
+    });
+  }
+
+  gpu("keeps eps meaningful on an all-but-zero row", async (r) => {
+    // Without this, dropping eps entirely still passes: on ordinary input
+    // sumSq/D dwarfs it. Here it is the only thing standing between the
+    // reciprocal square root and a division by zero.
+    const D = 8;
+    const input = new Float32Array(D);
+    const weight = new Float32Array(D).fill(1);
+    const eps = 1e-5;
+    const [out] = await r.run({
+      code: shader("rmsnorm"),
+      bindings: [
+        { kind: "storage", data: input },
+        { kind: "storage", data: weight },
+        { kind: "out", type: "f32", length: D },
+        { kind: "uniform", data: params([["u32", 1], ["u32", D], ["f32", eps]]) },
+      ],
+      workgroups: [1],
+    });
+    expect([...out!].every(Number.isFinite)).toBe(true);
+    agree(out!, refRMSNorm(input, weight, 1, D, eps));
+  });
+});
+
+describe("activation.wgsl", () => {
+  for (const [label, type] of [["ReLU²", 0], ["SiLU", 1]] as const) {
+    gpu(`matches the reference for ${label}`, async (r) => {
+      const input = Float32Array.from([-4, -2, -0.5, 0, 0.5, 2, 4, 10, -10, ...wave(64)]);
+      const [out] = await r.run({
+        code: shader("activation"),
+        bindings: [
+          { kind: "storage", data: input },
+          { kind: "out", type: "f32", length: input.length },
+          { kind: "uniform", data: params([["u32", input.length], ["u32", type]]) },
+        ],
+        workgroups: [Math.ceil(input.length / 256)],
+      });
+      agree(out!, refActivation(input, type));
+    });
+  }
+});
+
+describe("elementwise.wgsl", () => {
+  for (const [label, op] of [["add", 0], ["multiply", 1]] as const) {
+    gpu(`matches the reference for ${label}`, async (r) => {
+      const a = wave(300);
+      const b = wave(300, 0.19);
+      const [out] = await r.run({
+        code: shader("elementwise"),
+        bindings: [
+          { kind: "storage", data: a },
+          { kind: "storage", data: b },
+          { kind: "out", type: "f32", length: a.length },
+          { kind: "uniform", data: params([["u32", a.length], ["u32", op]]) },
+        ],
+        workgroups: [Math.ceil(a.length / 256)],
+      });
+      agree(out!, refElementwise(a, b, op));
+    });
+  }
+});
+
+describe("softmax.wgsl", () => {
+  for (const [N, D] of [[1, 16], [2, 256], [3, 500]] as const) {
+    gpu(`matches the reference at N=${N} D=${D}`, async (r) => {
+      const input = wave(N * D, 0.23);
+      const [out] = await r.run({
+        code: shader("softmax"),
+        bindings: [
+          { kind: "storage", data: input },
+          { kind: "out", type: "f32", length: N * D },
+          { kind: "uniform", data: params([["u32", N], ["u32", D]]) },
+        ],
+        workgroups: [N],
+      });
+      agree(out!, refSoftmax(input, N, D));
+    });
+  }
+
+  gpu("does not overflow on large logits", async (r) => {
+    // The max-subtraction is the whole reason softmax is written the way it is.
+    const D = 8;
+    const input = Float32Array.from([100, 200, 300, 400, 500, 600, 700, 800]);
+    const [out] = await r.run({
+      code: shader("softmax"),
+      bindings: [
+        { kind: "storage", data: input },
+        { kind: "out", type: "f32", length: D },
+        { kind: "uniform", data: params([["u32", 1], ["u32", D]]) },
+      ],
+      workgroups: [1],
+    });
+    expect([...out!].every(Number.isFinite)).toBe(true);
+    agree(out!, refSoftmax(input, 1, D));
+  });
+});
+
+describe("rope.wgsl", () => {
+  for (const posOffset of [0, 7]) {
+    gpu(`matches the reference at pos_offset=${posOffset}`, async (r) => {
+      const [N, heads, headDim, theta] = [3, 4, 16, 10000];
+      const input = wave(N * heads * headDim, 0.29);
+      const [out] = await r.run({
+        code: shader("rope"),
+        bindings: [
+          { kind: "storage", data: input },
+          { kind: "out", type: "f32", length: input.length },
+          {
+            kind: "uniform",
+            data: params([
+              ["u32", N], ["u32", heads], ["u32", headDim], ["u32", posOffset], ["f32", theta],
+            ]),
+          },
+        ],
+        workgroups: [Math.ceil(input.length / 256)],
+      });
+      // Loosened on measurement, not on principle. This GPU's sin and cos carry
+      // up to 1.86e-4 of absolute error — three orders of magnitude worse than
+      // f32 epsilon (1.2e-7) — and RoPE calls both per element. The kernel and
+      // the reference compute the same expression; `pow` was checked separately
+      // and agrees to 2.8e-7, so the transcendentals are the whole difference.
+      //
+      // Nothing tighter is achievable here, and a test that demanded it would
+      // be reporting the hardware rather than the shader.
+      agree(out!, refRoPE(input, N, heads, headDim, posOffset, theta), { abs: 1e-3 });
+    });
+  }
+});
+
+describe("quantize.wgsl", () => {
+  for (const [N, D] of [[1, 64], [2, 300]] as const) {
+    gpu(`matches the reference at N=${N} D=${D}`, async (r) => {
+      const input = wave(N * D, 0.41);
+      const [out, scales] = await r.run({
+        code: shader("quantize"),
+        bindings: [
+          { kind: "storage", data: input },
+          { kind: "out", type: "i32", length: N * D },
+          { kind: "out", type: "f32", length: N },
+          { kind: "uniform", data: params([["u32", N], ["u32", D]]) },
+        ],
+        workgroups: [N],
+      });
+      const want = refQuantize(input, N, D);
+      // Integers: rounding must agree exactly, not approximately.
+      expect([...out!]).toEqual([...want.output]);
+      agree(scales!, want.scales);
+    });
+  }
+});
+
+describe("dequantize.wgsl", () => {
+  gpu("matches the reference", async (r) => {
+    const input = Int32Array.from({ length: 300 }, (_, i) => ((i * 37) % 255) - 127);
+    const [weightScale, inputScale] = [0.0125, 0.031];
+    const [out] = await r.run({
+      code: shader("dequantize"),
+      bindings: [
+        { kind: "storage", data: input },
+        { kind: "out", type: "f32", length: input.length },
+        { kind: "uniform", data: params([["f32", weightScale]]) },
+        { kind: "uniform", data: params([["f32", inputScale]]) },
+        { kind: "uniform", data: params([["u32", input.length]]) },
+      ],
+      workgroups: [Math.ceil(input.length / 256)],
+    });
+    agree(out!, refDequantize(input, weightScale, inputScale));
+  });
+});

--- a/packages/core/src/shaders/__tests__/helpers/gpu.ts
+++ b/packages/core/src/shaders/__tests__/helpers/gpu.ts
@@ -1,0 +1,170 @@
+import { chromium, type Browser } from "playwright";
+import { createServer, type Server } from "node:http";
+
+/**
+ * Runs a shader on a real GPU and reads its outputs back.
+ *
+ * The tests beside this file check TypeScript references. Those references and
+ * the shaders are two transcriptions of the same intent, and nothing made them
+ * agree — this is what does.
+ *
+ * Two things about the environment, both learned the hard way:
+ *
+ * - `navigator.gpu` is absent on `about:blank`. WebGPU requires a secure
+ *   context, so the page is served from 127.0.0.1. With that, **headless works**
+ *   — the usual "WebGPU is not available headless" is normally this.
+ * - Playwright's bundled Chromium does not ship WebGPU. The system Chrome does.
+ */
+
+/** One entry of the shader's `@group(0)` layout, in binding order. */
+export type Binding =
+  | { kind: "storage"; data: Float32Array | Int32Array | Uint32Array }
+  | { kind: "out"; type: "f32" | "i32" | "u32"; length: number }
+  | { kind: "uniform"; data: ArrayBuffer };
+
+export interface Runner {
+  /** Dispatches `code` and returns one array per `out` binding, in order. */
+  run(options: {
+    code: string;
+    entry?: string;
+    bindings: Binding[];
+    workgroups: [number] | [number, number] | [number, number, number];
+  }): Promise<(Float32Array | Int32Array | Uint32Array)[]>;
+  close(): Promise<void>;
+}
+
+const CHROME = process.env.CHROME_PATH ?? "/opt/google/chrome/chrome";
+
+/** Resolves to null when there is no usable GPU, so suites can skip. */
+export async function createRunner(): Promise<Runner | null> {
+  let server: Server | undefined;
+  let browser: Browser | undefined;
+  try {
+    server = createServer((_, res) => {
+      res.setHeader("Content-Type", "text/html");
+      res.end("<!doctype html><title>wgsl</title>");
+    });
+    await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", () => resolve()));
+    const { port } = server.address() as { port: number };
+
+    browser = await chromium.launch({
+      headless: true,
+      executablePath: CHROME,
+      args: ["--enable-unsafe-webgpu", "--enable-features=Vulkan"],
+    });
+    const page = await browser.newPage();
+    await page.goto(`http://127.0.0.1:${port}/`);
+
+    // One device for the whole suite: an adapter per kernel is slow, and
+    // enough outstanding requests start failing outright.
+    const ready = await page.evaluate(async () => {
+      const adapter = await navigator.gpu?.requestAdapter();
+      if (!adapter) return false;
+      (globalThis as unknown as { __device: GPUDevice }).__device = await adapter.requestDevice();
+      return true;
+    });
+    if (!ready) throw new Error("no adapter");
+
+    return {
+      async run({ code, entry = "main", bindings, workgroups }) {
+        // Typed arrays do not survive the page boundary; bytes do.
+        const wire = bindings.map((b) =>
+          b.kind === "out"
+            ? { kind: "out" as const, type: b.type, length: b.length }
+            : {
+                kind: b.kind,
+                bytes: Array.from(
+                  new Uint8Array(
+                    b.kind === "uniform" ? b.data : b.data.buffer.slice(b.data.byteOffset, b.data.byteOffset + b.data.byteLength),
+                  ),
+                ),
+              },
+        );
+
+        const results = await page.evaluate(
+          async ({ code, entry, wire, workgroups }) => {
+            const device = (globalThis as unknown as { __device: GPUDevice }).__device;
+            const U = GPUBufferUsage;
+            const outs: { index: number; buffer: GPUBuffer; bytes: number }[] = [];
+
+            const buffers = wire.map((b, index) => {
+              if (b.kind === "out") {
+                const bytes = b.length * 4;
+                const buffer = device.createBuffer({ size: bytes, usage: U.STORAGE | U.COPY_SRC });
+                outs.push({ index, buffer, bytes });
+                return buffer;
+              }
+              const data = new Uint8Array(b.bytes!);
+              const usage = b.kind === "uniform" ? U.UNIFORM | U.COPY_DST : U.STORAGE | U.COPY_DST;
+              // Uniform buffers have a 16-byte minimum binding size.
+              const size = Math.max(b.kind === "uniform" ? 16 : 4, data.byteLength);
+              const buffer = device.createBuffer({ size, usage });
+              device.queue.writeBuffer(buffer, 0, data);
+              return buffer;
+            });
+
+            const pipeline = device.createComputePipeline({
+              layout: "auto",
+              compute: { module: device.createShaderModule({ code }), entryPoint: entry },
+            });
+            const bindGroup = device.createBindGroup({
+              layout: pipeline.getBindGroupLayout(0),
+              entries: buffers.map((buffer, binding) => ({ binding, resource: { buffer } })),
+            });
+
+            const enc = device.createCommandEncoder();
+            const pass = enc.beginComputePass();
+            pass.setPipeline(pipeline);
+            pass.setBindGroup(0, bindGroup);
+            pass.dispatchWorkgroups(...(workgroups as [number, number?, number?]));
+            pass.end();
+
+            const reads = outs.map(({ buffer, bytes }) => {
+              const read = device.createBuffer({ size: bytes, usage: U.COPY_DST | U.MAP_READ });
+              enc.copyBufferToBuffer(buffer, 0, read, 0, bytes);
+              return read;
+            });
+            device.queue.submit([enc.finish()]);
+
+            const out: number[][] = [];
+            for (const read of reads) {
+              await read.mapAsync(GPUMapMode.READ);
+              out.push(Array.from(new Uint8Array(read.getMappedRange())));
+            }
+            return out;
+          },
+          { code, entry, wire, workgroups },
+        );
+
+        const outSpecs = bindings.filter((b): b is Extract<Binding, { kind: "out" }> => b.kind === "out");
+        return results.map((bytes, i) => {
+          const buffer = new Uint8Array(bytes).buffer;
+          const type = outSpecs[i]!.type;
+          if (type === "i32") return new Int32Array(buffer);
+          if (type === "u32") return new Uint32Array(buffer);
+          return new Float32Array(buffer);
+        });
+      },
+      async close() {
+        await browser?.close();
+        server?.close();
+      },
+    };
+  } catch {
+    await browser?.close();
+    server?.close();
+    return null;
+  }
+}
+
+/** Packs a params struct of mixed u32 / i32 / f32 into a uniform buffer. */
+export function params(fields: ["u32" | "i32" | "f32", number][]): ArrayBuffer {
+  const buffer = new ArrayBuffer(Math.max(16, fields.length * 4));
+  const view = new DataView(buffer);
+  fields.forEach(([kind, value], i) => {
+    if (kind === "f32") view.setFloat32(i * 4, value, true);
+    else if (kind === "i32") view.setInt32(i * 4, value, true);
+    else view.setUint32(i * 4, value, true);
+  });
+  return buffer;
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/__tests__/**/*.test.ts"],
+    // The GPU suite has its own config: it needs a browser and a real adapter,
+    // and CI has neither. See vitest.gpu.config.ts.
+    exclude: ["**/node_modules/**", "src/**/__tests__/gpu/**"],
   },
 });

--- a/packages/core/vitest.gpu.config.ts
+++ b/packages/core/vitest.gpu.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Separate from vitest.config.ts on purpose. These tests need a GPU, CI runs on
+ * ubuntu-latest without one, and the suite that gates pull requests should be
+ * the one that can actually run there.
+ */
+export default defineConfig({
+  test: {
+    include: ["src/**/__tests__/gpu/**/*.gpu.test.ts"],
+    testTimeout: 60_000,
+    hookTimeout: 120_000,
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
Closes #29

## What was missing

Twelve shaders, eighteen test files, and **nothing executed WGSL** — `requestAdapter` and `createShaderModule` appear in zero of them. Every test exercises a TypeScript reference, so the shader and the reference were two transcriptions of the same intent with nothing holding them together. One name admits it: `refTernaryGemvShaderLogic`.

The kernels are not in doubt. The model runs in a browser and produces coherent text, which is a stronger signal than any unit test. What was missing is **per-kernel** verification, and the reason to want it now is fusion — `activation` → `elementwise(multiply)` in `FFN.forwardGated` is two dispatches where one would do, and `BitLinear.forward` runs RMSNorm and Quantize separately despite a comment calling them fused. "Still coherent" cannot tell a correct fusion from a subtly wrong one.

## What this covers

Seven shaders — `rmsnorm`, `activation`, `elementwise`, `softmax`, `rope`, `quantize`, `dequantize` — with `D` chosen to span the 256-wide workgroup: below it, exactly on it, and not a multiple of it, since the strided loop and the reduction each depend on which.

Five are left: `attention`, `embedding`, `f32_matmul`, `ternary_gemm`, `ternary_gemv`. They need packed I2_S data and embedding tables constructed first, which is its own piece of work rather than a footnote to this one.

## Two findings

**`eps` in rmsnorm was untested.** Removing it entirely still passed — on ordinary input `sumSq/D` dwarfs it. There is now an all-but-zero row where it is the only thing standing between `inverseSqrt` and a division by zero.

**`rope` cannot be checked to f32 precision, and the reason is the hardware.** Measured on this GPU:

| | absolute error |
|---|---|
| `sin` / `cos` | up to **1.86e-4** |
| f32 epsilon | 1.2e-7 |
| `pow` (measured separately) | 2.8e-7 |

Three orders of magnitude worse than f32, and RoPE calls both per element — which fully accounts for its 3.37e-4. The shader and the reference compute the *same expression*; I checked. So the tolerance is loosened **on measurement, with the number recorded in the test**, rather than quietly widened until it went green.

Worth knowing generally: no shader using `sin`, `cos` or `exp` can be validated tighter than this.

## Proven to catch damage

Mutating `rmsnorm.wgsl` to drop the `weight` multiply fails 4 tests. Dropping a reduction barrier fails too. A harness that only ever passes would be worse than none.

## Kept out of `npm test`

CI is `ubuntu-latest` with no GPU, and the suite that gates pull requests should be one that can run there. Separate config, separate script (`npm run test:gpu`), excluded from the default include. It also **skips rather than fails** when no adapter is present, so it does not punish a contributor without one.

```
npm test       → 99 passed | 28 skipped   (no GPU needed)
npm run test:gpu → 18 passed              (this machine)
CHROME_PATH=/nonexistent npm run test:gpu → 18 passed (all skipped)
```

## Two environment notes, since both cost time

- **`navigator.gpu` is absent on `about:blank`.** WebGPU needs a secure context, so the page is served from `127.0.0.1`. With that, **headless works** — which is usually what "WebGPU is unavailable headless" turns out to mean.
- **Playwright's bundled Chromium does not ship WebGPU.** The system Chrome does. `CHROME_PATH` overrides the default `/opt/google/chrome/chrome`.

## Next

Fusing `activation` + `elementwise(multiply)` into one dispatch, and RMSNorm + Quantize in `BitLinear`. Both can now be shown to match what they replace.